### PR TITLE
Readme update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ You need to use _PackageReference_, otherwise some contents will not be copied t
 
 ## Currently supported features
 
+All functions also exist in an asynchronous version.
+
 ## STLINK functions
 - GetStLinkList
 - GetStLinkEnumerationList
@@ -163,6 +165,12 @@ cubeProgrammerApi.SetVerbosityLevel(CubeProgrammerVerbosityLevel.CubeprogrammerV
 
 ```csharp
 var stLinkList = cubeProgrammerApi.GetStLinkEnumerationList();
+```
+
+or
+
+```csharp
+var stLinkList = await cubeProgrammerApi.GetStLinkEnumerationListAsync();
 ```
 
 - Connect:

--- a/docs/KSociety.SharpCubeProgrammer/README.md
+++ b/docs/KSociety.SharpCubeProgrammer/README.md
@@ -36,6 +36,8 @@ You need to use _PackageReference_, otherwise some contents will not be copied t
 
 ## Currently supported features
 
+All functions also exist in an asynchronous version.
+
 ## STLINK functions
 - GetStLinkList
 - GetStLinkEnumerationList
@@ -158,6 +160,12 @@ cubeProgrammerApi.SetVerbosityLevel(CubeProgrammerVerbosityLevel.CubeprogrammerV
 
 ```csharp
 var stLinkList = cubeProgrammerApi.GetStLinkEnumerationList();
+```
+
+or
+
+```csharp
+var stLinkList = await cubeProgrammerApi.GetStLinkEnumerationListAsync();
 ```
 
 - Connect:


### PR DESCRIPTION
All methods are now also in asynchronous version.
For example:

 public CubeProgrammerError ConnectStLink(DebugConnectParameters debugConnectParameters) 

 public async ValueTask<CubeProgrammerError> ConnectStLinkAsync(DebugConnectParameters debugConnectParameters, CancellationToken cancellationToken = default)